### PR TITLE
v2 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Leonid Emar-Kar
+Copyright (c) 2026 Leonid Emar-Kar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,89 +1,189 @@
 # find
-Simple find module for go applications
 
-### Install:
+A lightweight Go package for searching files and folders by pattern. Zero
+dependencies, context-aware, and built on Go 1.23+ iterators.
+
+## Install
 
 ```bash
-go get github.com/emar-kar/find@latest
+go get github.com/emar-kar/find/v2
 ```
 
-### Usage:
-
-Find allows to search files and folders with the given template:
+## Quick start
 
 ```go
-ctx, cancel := context.WithDeadline(
-  context.Background(),
-  time.Now().Add(5*time.Minute),
-)
-defer cancel()
+// Stream results with FindSeq (recommended).
+for path, err := range find.FindSeq(ctx, "/src", "*.go", find.Recursive) {
+    if err != nil {
+        log.Println(err)
+        continue
+    }
+    fmt.Println(path)
+}
+```
 
-where := "path/to/the/source"
+`FindSeq` returns an `iter.Seq2[string, error]` — use it with `for range`,
+`break` out whenever you want, and handle errors inline.
 
-// Since recursive search does not active by default,
-// Find will search for files and folders only in the
-// root of where.
-results, err := Find(ctx, where, "*template*")
+## Pattern syntax
+
+Patterns are parsed by `ParseTemplate`. A single string can express
+wildcards, negation, boolean operators, and grouping:
+
+| Pattern    | Meaning                               |
+|------------|---------------------------------------|
+| `*str*`    | path contains *str*                   |
+| `str`      | path equals *str* (segment boundary)  |
+| `*str`     | path ends with *str*                  |
+| `str*`     | path starts with *str*                |
+| `!pattern` | negation — path must **not** match    |
+| `a&b`      | AND — both must match                 |
+| `a\|b`     | OR — either must match                |
+| `(a\|b)&c` | parentheses override precedence       |
+
+`&` binds tighter than `|`, so `*go*&!*test*|*.md` is parsed as
+`(*go* AND !*test*) OR *.md`.
+
+The only universal wildcard is `*` (matches everything). `**` is normalised
+to `*`.
+
+### Examples
+
+```
+*.go                   — all Go files
+*go*&!*test*           — Go files, excluding tests
+(*go*|*.md)&!*vendor*  — Go or Markdown, excluding vendor
+!(*.log|*.tmp)         — anything except logs and temp files
+```
+
+## API
+
+### FindSeq *(recommended)*
+
+```go
+func FindSeq(ctx context.Context, where, pattern string, opts ...Option) iter.Seq2[string, error]
+```
+
+Iterator-based search. Yields `(path, nil)` for each match and `("", err)`
+for errors. Setup errors (bad path, malformed pattern) appear on the first
+iteration. Use `break` to stop early.
+
+### Find
+
+```go
+func Find[T Templater](ctx context.Context, where string, t T, opts ...Option) ([]string, error)
+```
+
+Collects all matches into a slice and returns them. Kept for backward
+compatibility — prefer `FindSeq` for streaming results without allocating a
+result slice. Accepts `string` or `[]string` patterns.
+
+### FindWithIterator *(deprecated)*
+
+```go
+func FindWithIterator[T Templater](ctx context.Context, where string, t T, opts ...Option) (chan string, chan error)
+```
+
+Channel-based iteration. **Deprecated** — use `FindSeq` instead.
+
+### ParseTemplate
+
+```go
+func ParseTemplate(str string) (*Template, error)
+```
+
+Parses a pattern string into a reusable `*Template`. Returns
+`ErrMalformedPattern` for invalid input (empty segments, unbalanced
+parentheses). Useful when you need to match paths independently of a
+directory walk.
+
+## Options
+
+Options follow the standard Go functional-options pattern. Build reusable
+option slices with `[]find.Option{...}`.
+
+| Option            | Description                                            |
+|-------------------|--------------------------------------------------------|
+| `Recursive`       | Search subdirectories recursively.                     |
+| `Only(t)`         | Filter by type: `File`, `Folder`, or `Both` (default). |
+| `NamesOnly`       | Return entry names only, not full paths.               |
+| `RelativePaths`   | Keep paths relative to *where*.                        |
+| `MatchFullPath`   | Match against the full path, not just the entry name.  |
+| `CaseInsensitive` | Case-insensitive pattern matching.                     |
+| `FollowSymlinks`  | Resolve and follow symlinks during traversal.          |
+| `Max(n)`          | Limit the number of results.                           |
+| `Strict`          | AND-join `[]string` patterns instead of OR-join.       |
+| `SkipErrors`      | Silently ignore non-critical errors (`Find` only).     |
+
+### Deprecated options
+
+These remain for `Find`/`FindWithIterator` compatibility. With `FindSeq`,
+handle output and errors directly in the loop.
+
+| Option             | Replacement                              |
+|--------------------|------------------------------------------|
+| `LogErrors`        | Handle errors in the `FindSeq` loop.     |
+| `WithOutput`       | Print matches in the `FindSeq` loop.     |
+| `WithWriter(w)`    | Write matches in the `FindSeq` loop.     |
+| `WithLogger(w)`    | Log errors in the `FindSeq` loop.        |
+| `WithMaxIterator(n)` | Not needed — `FindSeq` has no channel. |
+
+## Usage examples
+
+### Recursive search with max results
+
+```go
+for path, err := range find.FindSeq(ctx, ".", "*.go",
+    find.Recursive,
+    find.Max(10),
+) {
+    if err != nil {
+        log.Println(err)
+        continue
+    }
+    fmt.Println(path)
+}
+```
+
+### Case-insensitive search for folders
+
+```go
+for path, err := range find.FindSeq(ctx, "/var", "logs",
+    find.Recursive,
+    find.Only(find.Folder),
+    find.CaseInsensitive,
+) {
+    if err != nil {
+        log.Println(err)
+        continue
+    }
+    fmt.Println(path)
+}
+```
+
+### Reusable option sets
+
+```go
+opts := []find.Option{
+    find.Recursive,
+    find.CaseInsensitive,
+    find.Only(find.File),
+}
+
+for path, err := range find.FindSeq(ctx, root, "*.go", opts...) {
+    // ...
+}
+```
+
+### Using ParseTemplate directly
+
+```go
+tmpl, err := find.ParseTemplate("*go*&!*test*")
 if err != nil {
-  log.Println(err)
-
-  return
+    log.Fatal(err)
 }
 
-for _, r := range results {
-  fmt.Println(r)
+if tmpl.Match("cmd/server/main.go") {
+    fmt.Println("matched")
 }
 ```
-
-### Setup:
-
-Find supports several options for search customization:
-
-* ~~`SearchFor`~~ is deprecated, use `Only` instead;
-* `Only` - defines the type of the searched object: files, folders or both;
-	```go
-	// Type of the searched object.
-	const (
-		File uint8 = iota
-		Folder
-		Both
-	)
-	```
-* ~~`SearchRecursively`~~ is deprecated, use `Recursively` instead;
-* `Recursively` - activates recursive search, disabled by default;
-* ~~`SearchName`~~ is deprecated, use `Name` instead;
-* `Name` - result will containt only names of the searched objects, not paths;
-* ~~`SearchStrict`~~ is deprecated, use `Strict` instead;
-* `Strict` - since Find supports passing several templates during search, by default path will be returned if it matchs any of the given templates. This option switch this behavior to match all of the templates;
-* `MatchTree` - matches the whole path instead of the object name;
-* `RelativePaths` - does not resolve paths in output;
-* `WithErrorsSkip` - skips errors during execution, returns **nil** in result, only if the root where was resolved;
-* `WithErrosLog` - logs errors during execution;
-* `WithOutput` - prints found paths during the process, before return.
-
-```go
-// defaultOptions default Find options.
-func defaultOptions() *options {
-	return &options{
-		matchFunc: MatchAny,
-		fType:     Both,
-		rec:       false,
-		name:      false,
-	}
-}
-```
-
-Find uses generic templates, which can be a simple `string` type or a slice of strings `[]string{}`.
-
-String can contain the following setup:
-
-* `str&str1` - means that searched path should be both str and str1
-* `str|str1` - means that searched path should be str or str1
-* `*str`     - means that searched path should ends with str
-* `str*`     - means that searched path should starts with str
-* `*str*`    - means that searched path should contain str
-* `str`      - means that searched path should be str
-* `!str`     - means that searched path should not be str
-* `!*str`    - means that searched path should not end with str
-* `!str*`    - means that searched path should not start with str
-* `!*str*`   - means that searched path should not contain str

--- a/find.go
+++ b/find.go
@@ -1,170 +1,75 @@
-// Package find allows to search for files/folders with options.
+// Package find searches for files and folders matching configurable patterns.
 package find
 
 import (
 	"context"
+	"fmt"
+	"iter"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-// FindWithIterator acts the same way as [Find] but returns channels instead.
-// String channel will return every match. Error channel returns first occured
-// error during search or if [WithErrorsSkip] was set, first critical error.
-// As soon as search is over or interrupted, both channels will be closed.
-// For example:
+// FindSeq returns an iterator over all matches of pattern in where.
+// It can be used directly with range:
 //
-//	outCh, errCh := FindWithIterator(ctx, where, ts, opts...)
-//	for f := range outCh {
-//		// do something here...
-//	}
-//	if err := <-errCh {
-//		// process error...
+//	for path, err := range FindSeq(ctx, "/some/dir", "*.go") {
+//	    if err != nil {
+//	        // handle or break
+//	        continue
+//	    }
+//	    fmt.Println(path)
 //	}
 //
-// NOTE: output channel should be cosumed by the caller.
-// Overwise it can cause a deadlock.
-func FindWithIterator[T Templater](
-	ctx context.Context,
-	where string,
-	t T,
-	opts ...optFunc,
-) (chan string, chan error) {
-	opt := defaultOptionsWithCustom(opts...)
+// Setup errors (unresolvable path, malformed pattern) are yielded as
+// ("", err) on the first iteration. Mid-walk errors (e.g. permission
+// denied on a subdirectory) are yielded and traversal continues; use
+// break to stop early at any point.
+//
+// See [ParseTemplate] for the full pattern syntax.
+func FindSeq(
+	ctx context.Context, where, pattern string, opts ...Option,
+) iter.Seq2[string, error] {
+	opt := defaultOptions()
 
-	opt.iterCh = make(chan string, opt.maxIter)
-	opt.errCh = make(chan error, 1)
-	opt.iter = true
+	for _, fn := range opts {
+		fn(opt)
+	}
 
-	go func() {
-		defer func() {
-			close(opt.iterCh)
-			close(opt.errCh)
-		}()
+	return findSeqWithOpts(ctx, where, pattern, opt)
+}
 
-		resPath, err := resolvePath(where)
+// findSeqWithOpts is the internal implementation of [FindSeq] that accepts
+// a pre-built *options, allowing [Find] and [FindWithIterator] to share
+// the same options struct without double-instantiation.
+func findSeqWithOpts(
+	ctx context.Context, where, pattern string, opt *options,
+) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		rp, err := resolvePath(where)
 		if err != nil {
-			opt.errCh <- err
+			yield("", err)
 			return
 		}
 
 		opt.orig = where
-		opt.resOrig = resPath
+		opt.resOrig = rp
 
-		ts, err := newTemplates(t, opt.caseFunc)
+		tmpl, err := ParseTemplate(opt.caseFunc(pattern))
 		if err != nil {
-			opt.errCh <- err
+			yield("", err)
 			return
 		}
 
-		if err := find(ctx, resPath, ts, opt, nil); err != nil {
-			opt.errCh <- err
-		}
-	}()
+		opt.tmpl = tmpl
 
-	return opt.iterCh, opt.errCh
+		findSeq(ctx, rp, opt, yield)
+	}
 }
 
-// Find searches for matches with the given templates in where.
-func Find[T Templater](
-	ctx context.Context,
-	where string,
-	t T,
-	opts ...optFunc,
-) ([]string, error) {
-	// Primary path resolution, even if `skip` flag was set,
-	// this error is critical and should not be omitted.
-	resPath, err := resolvePath(where)
-	if err != nil {
-		return nil, err
-	}
-
-	opt := defaultOptionsWithCustom(opts...)
-
-	// Pre-save location file and its resolved path, for further
-	// usage if relative paths will be needed.
-	opt.orig = where
-	opt.resOrig = resPath
-
-	ts, err := newTemplates(t, opt.caseFunc)
-	if err != nil {
-		return nil, err
-	}
-
-	var result []string
-	if opt.max > 0 {
-		result = make([]string, 0, opt.max)
-	} else {
-		result = make([]string, 0, 10)
-	}
-
-	err = find(ctx, resPath, ts, opt, &result)
-
-	return result, err
-}
-
-func find(
-	ctx context.Context,
-	where string,
-	ts Templates,
-	opt *options,
-	result *[]string,
-) error {
-	resPath, entries, err := readAndResolve(where)
-	if err != nil {
-		return opt.logError(err)
-	}
-
-	for _, f := range entries {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			if opt.max == 0 {
-				return nil
-			}
-
-			p := filepath.Join(resPath, f.Name())
-
-			var found string
-
-			if opt.isSearchedType(f.IsDir()) && opt.match(ts, p) {
-				switch {
-				case opt.name:
-					found = f.Name()
-				case opt.relative:
-					found = strings.ReplaceAll(p, opt.resOrig, opt.orig)
-				default:
-					found = p
-				}
-
-				if err := opt.printOutput(found); err != nil {
-					return opt.logError(err)
-				}
-
-				if opt.iter {
-					opt.iterCh <- found
-				} else {
-					*result = append(*result, found)
-				}
-
-				if opt.max != -1 {
-					opt.max--
-				}
-			}
-
-			if opt.rec && f.IsDir() {
-				if err := find(ctx, p, ts, opt, result); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-// resolvePath resolves symlinks and relative paths.
+// resolvePath returns the absolute real path for p. It calls [os.Lstat] to
+// check for symlinks, resolves them via [filepath.EvalSymlinks] if present,
+// and converts the result to an absolute path.
 func resolvePath(p string) (string, error) {
 	info, err := os.Lstat(p)
 	if err != nil {
@@ -180,13 +85,265 @@ func resolvePath(p string) (string, error) {
 	return filepath.Abs(p)
 }
 
-func readAndResolve(p string) (string, []os.DirEntry, error) {
-	resPath, err := resolvePath(p)
+// findSeq reads rp and processes each entry, yielding matches via yield.
+// Returns false as soon as yield signals the caller wants to stop.
+func findSeq(
+	ctx context.Context,
+	rp string,
+	opt *options,
+	yield func(string, error) bool,
+) bool {
+	entries, err := os.ReadDir(rp)
 	if err != nil {
-		return "", nil, err
+		// Yield the error but keep walking the parent directory.
+		return yield("", err)
 	}
 
-	data, err := os.ReadDir(resPath)
+	for _, f := range entries {
+		select {
+		case <-ctx.Done():
+			yield("", ctx.Err())
+			return false
+		default:
+			if opt.max == 0 {
+				return false
+			}
 
-	return resPath, data, err
+			p := filepath.Join(rp, f.Name())
+
+			if !processEntrySeq(ctx, f, p, opt, yield) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// processEntrySeq handles a single directory entry for [FindSeq]: match,
+// yield, and optionally recurse. Returns false when yield signals stop.
+func processEntrySeq(
+	ctx context.Context,
+	f os.DirEntry,
+	p string,
+	opt *options,
+	yield func(string, error) bool,
+) bool {
+	isDir := f.IsDir()
+	isSymlink := f.Type()&os.ModeSymlink != 0
+
+	// Resolve symlinks only when explicitly requested via FollowSymlinks.
+	if isSymlink && opt.symlinks {
+		info, err := os.Stat(p)
+		if err != nil {
+			return yield("", err)
+		}
+
+		isDir = info.IsDir()
+	}
+
+	if opt.isSearchedType(isDir) && opt.match(p, f.Name()) {
+		found := formatFound(f, p, opt)
+
+		if err := opt.printOutput(found); err != nil {
+			return yield("", err)
+		}
+
+		if !yield(found, nil) {
+			return false
+		}
+
+		if opt.max != -1 {
+			opt.max--
+		}
+	}
+
+	// Do not recurse if max has already been reached.
+	if opt.rec && isDir && opt.max != 0 {
+		rp := p
+
+		if isSymlink && opt.symlinks {
+			// Resolve the symlink so findSeq receives an absolute real path.
+			var err error
+
+			rp, err = filepath.EvalSymlinks(p)
+			if err != nil {
+				return yield("", err)
+			}
+		}
+
+		return findSeq(ctx, rp, opt, yield)
+	}
+
+	return true
+}
+
+// formatFound returns the display form of path p according to opt flags.
+func formatFound(f os.DirEntry, p string, opt *options) string {
+	switch {
+	case opt.name:
+		return f.Name()
+	case opt.relative:
+		return strings.Replace(p, opt.resOrig, opt.orig, 1)
+	default:
+		return p
+	}
+}
+
+// FindWithIterator returns channel-based iteration over matches.
+// String channel yields every match. Error channel carries the first
+// occurred error or, if [SkipErrors] was set, the first critical error.
+// Both channels are closed once the search completes or is interrupted.
+//
+//	outCh, errCh := FindWithIterator(ctx, where, ts, opts...)
+//	for f := range outCh {
+//		// do something here...
+//	}
+//	if err := <-errCh {
+//		// process error...
+//	}
+//
+// NOTE: output channel must be consumed by the caller to avoid a deadlock.
+//
+// Deprecated: use [FindSeq] instead for pull-based iteration without
+// goroutines or channels.
+func FindWithIterator[T Templater](
+	ctx context.Context,
+	where string,
+	t T,
+	opts ...Option,
+) (chan string, chan error) {
+	opt := defaultOptions()
+
+	for _, fn := range opts {
+		fn(opt)
+	}
+
+	iterCh := make(chan string, opt.maxIter)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer func() {
+			close(iterCh)
+			close(errCh)
+		}()
+
+		resPath, err := resolvePath(where)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		opt.orig = where
+		opt.resOrig = resPath
+
+		var pattern string
+		switch v := any(t).(type) {
+		case string:
+			pattern = v
+		case []string:
+			pattern = ParsePattern(opt.strict, v...)
+		default:
+			errCh <- fmt.Errorf("%w: %v", ErrTemplateType, t)
+			return
+		}
+
+		tmpl, err := ParseTemplate(opt.caseFunc(pattern))
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		opt.tmpl = tmpl
+
+		if err := findOld(ctx, resPath, opt, iterCh, nil); err != nil {
+			errCh <- err
+		}
+	}()
+
+	return iterCh, errCh
+}
+
+// Find searches for matches with the given templates in where and returns
+// all results as a slice. Accepts a string or []string pattern (see
+// [Templater]). Use Find when you need the complete result set before
+// processing; use [FindSeq] when streaming or early termination is preferred.
+func Find(
+	ctx context.Context, where, pattern string, opts ...Option,
+) ([]string, error) {
+	result := make([]string, 0, 10)
+
+	for found, err := range FindSeq(ctx, where, pattern, opts...) {
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, found)
+	}
+
+	return result, nil
+}
+
+// findOld is the original recursive traversal used by [Find] and
+// [FindWithIterator]. When iterCh is non-nil, matches are sent to the
+// channel; otherwise they are appended to result.
+func findOld(
+	ctx context.Context,
+	where string,
+	opt *options,
+	iterCh chan<- string,
+	result *[]string,
+) error {
+	entries, err := os.ReadDir(where)
+	if err != nil {
+		return opt.logError(err)
+	}
+
+	for _, f := range entries {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if opt.max == 0 {
+				return nil
+			}
+
+			p := filepath.Join(where, f.Name())
+
+			if opt.isSearchedType(f.IsDir()) && opt.match(p, f.Name()) {
+				var found string
+
+				switch {
+				case opt.name:
+					found = f.Name()
+				case opt.relative:
+					found = strings.Replace(p, opt.resOrig, opt.orig, 1)
+				default:
+					found = p
+				}
+
+				if err := opt.printOutput(found); err != nil {
+					return opt.logError(err)
+				}
+
+				if iterCh != nil {
+					iterCh <- found
+				} else {
+					*result = append(*result, found)
+				}
+
+				if opt.max != -1 {
+					opt.max--
+				}
+			}
+
+			if opt.rec && f.IsDir() {
+				if err := findOld(ctx, p, opt, iterCh, result); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/find_test.go
+++ b/find_test.go
@@ -2,98 +2,835 @@ package find
 
 import (
 	"context"
-	"fmt"
-	"log"
+	"errors"
 	"os"
-	"time"
+	"path/filepath"
+	"slices"
+	"sort"
+	"testing"
 )
 
-func ExampleFind() {
-	ctx, cancel := context.WithDeadline(
-		context.Background(),
-		time.Now().Add(5*time.Minute),
-	)
-	defer cancel()
+// testTree creates a temporary directory structure for testing:
+//
+//	root/
+//	  file.go
+//	  file.txt
+//	  file_test.go
+//	  README.md
+//	  sub/
+//	    nested.go
+//	    nested_test.go
+//	    deep/
+//	      deep.go
+func testTree(t *testing.T) string {
+	t.Helper()
 
-	where := "path/to/the/source"
+	root := t.TempDir()
 
-	// Since recursive search does not active by default,
-	// Find will search for files and folders only in the
-	// root of where.
-	results, err := Find(ctx, where, "*template*")
-	if err != nil {
-		log.Println(err)
-
-		return
+	dirs := []string{
+		"sub",
+		filepath.Join("sub", "deep"),
 	}
 
-	for _, r := range results {
-		fmt.Println(r)
+	files := []string{
+		"file.go",
+		"file.txt",
+		"file_test.go",
+		"README.md",
+		filepath.Join("sub", "nested.go"),
+		filepath.Join("sub", "nested_test.go"),
+		filepath.Join("sub", "deep", "deep.go"),
+	}
+
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(root, f), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return root
+}
+
+// names extracts basenames from a list of absolute paths.
+func names(paths []string) []string {
+	out := make([]string, len(paths))
+	for i, p := range paths {
+		out[i] = filepath.Base(p)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// --- ParseTemplate tests ---
+
+func TestParseTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		{"wildcard contains", "*go*", "file.go", true},
+		{"wildcard contains negative", "*go*", "file.txt", false},
+		{"wildcard suffix", "*.go", "file.go", true},
+		{"wildcard suffix negative", "*.go", "file.txt", false},
+		{"wildcard prefix", "file*", "file.go", true},
+		{"wildcard prefix negative", "file*", "other.go", false},
+		{"exact segment", "file.go", "file.go", true},
+		{"exact segment negative", "file.go", "file.txt", false},
+		{"exact in path", "sub", "foo/sub/bar", true},
+		{"negation", "!*.txt", "file.go", true},
+		{"negation negative", "!*.txt", "file.txt", false},
+		{"and", "*go*&!*test*", "file.go", true},
+		{"and negative", "*go*&!*test*", "file_test.go", false},
+		{"or", "*.go|*.txt", "file.go", true},
+		{"or second", "*.go|*.txt", "file.txt", true},
+		{"or negative", "*.go|*.txt", "README.md", false},
+		{"precedence and-or", "*go*&!*test*|*.md", "file_test.go", false},
+		{"precedence and-or md", "*go*&!*test*|*.md", "README.md", true},
+		{"parens override", "(*go*|*.md)&!*test*", "file.go", true},
+		{"parens override negative", "(*go*|*.md)&!*test*", "file_test.go", false},
+		{"negated group", "!(*.go|*.txt)", "README.md", true},
+		{"negated group negative", "!(*.go|*.txt)", "file.go", false},
+		{"universal wildcard", "*", "anything", true},
+		{"double wildcard normalised", "**", "anything", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := ParseTemplate(tt.pattern)
+			if err != nil {
+				t.Fatalf("ParseTemplate(%q) error: %v", tt.pattern, err)
+			}
+
+			if got := tmpl.Match(tt.input); got != tt.want {
+				t.Errorf("ParseTemplate(%q).Match(%q) = %v, want %v",
+					tt.pattern, tt.input, got, tt.want)
+			}
+		})
 	}
 }
 
-func ExampleFind_withOptions() {
-	ctx, cancel := context.WithDeadline(
-		context.Background(),
-		time.Now().Add(5*time.Minute),
-	)
-	defer cancel()
-
-	where := "path/to/the/source"
-
-	// Results will contain only folders searched recursively.
-	results, err := Find(
-		ctx,
-		where,
-		"*template*",
-		Only(Folder),
-		Recursively,
-	)
-	if err != nil {
-		log.Println(err)
-
-		return
+func TestParseTemplateMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{"trailing pipe", "a|"},
+		{"leading pipe", "|b"},
+		{"trailing ampersand", "a&"},
+		{"empty string", ""},
+		{"unmatched open paren", "(a|b"},
+		{"unmatched close paren", "a|b)"},
 	}
 
-	for _, r := range results {
-		fmt.Println(r)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseTemplate(tt.pattern)
+			if err == nil {
+				t.Fatalf("ParseTemplate(%q) expected error, got nil", tt.pattern)
+			}
+
+			if !errors.Is(err, ErrMalformedPattern) {
+				t.Errorf("ParseTemplate(%q) error = %v, want %v",
+					tt.pattern, err, ErrMalformedPattern)
+			}
+		})
 	}
 }
 
-func ExampleTemplate_standalone() {
-	template := NewTemplate("*custom*&*template*")
+// --- FindSeq tests ---
 
-	// Can be any string slice, resulted from different sources.
-	s, err := os.ReadDir("some/folder")
-	if err != nil {
-		log.Fatalln(err)
+func TestFindSeqBasic(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*.go") {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
 	}
 
-	for _, el := range s {
-		if template.Match(el.Name()) {
-			// Do something here...
+	want := []string{"file.go", "file_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("FindSeq(*.go) names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSeqRecursive(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*.go", Recursive) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	want := []string{"deep.go", "file.go", "file_test.go", "nested.go", "nested_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("FindSeq recursive names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSeqCaseInsensitive(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*.GO", CaseInsensitive) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	want := []string{"file.go", "file_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("FindSeq case-insensitive names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSeqMax(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*", Max(2)) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	if len(got) != 2 {
+		t.Errorf("FindSeq Max(2) returned %d results, want 2", len(got))
+	}
+}
+
+func TestFindSeqNamesOnly(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*.go", NamesOnly) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	for _, p := range got {
+		if filepath.Base(p) != p {
+			t.Errorf("NamesOnly returned path %q, expected base name only", p)
 		}
 	}
 }
 
-func ExampleTemplates() {
-	ts := []string{"*this*", "*that*"}
+func TestFindSeqRelativePaths(t *testing.T) {
+	root := testTree(t)
 
-	templates := NewTemplates(ts)
-
-	// Can be any string slice, resulted from different sources.
-	s, err := os.ReadDir("some/folder")
+	// Use a relative path as 'where' so RelativePaths produces relative output.
+	orig, err := os.Getwd()
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 
-	for _, el := range s {
-		if MatchAny(templates, el.Name()) {
-			// Do something here if match any of the templates...
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), ".", "*.go", RelativePaths) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	for _, p := range got {
+		if filepath.IsAbs(p) {
+			t.Errorf("RelativePaths returned absolute path %q", p)
+		}
+	}
+}
+
+func TestFindSeqOnlyFiles(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*", Only(File)) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	// "sub" is a directory and should not appear.
+	for _, p := range got {
+		if filepath.Base(p) == "sub" {
+			t.Error("Only(File) returned directory 'sub'")
+		}
+	}
+}
+
+func TestFindSeqOnlyFolders(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*", Only(Folder)) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	want := []string{"sub"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("Only(Folder) names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSeqAndPattern(t *testing.T) {
+	root := testTree(t)
+
+	var got []string
+	for p, err := range FindSeq(context.Background(), root, "*go*&!*test*", Recursive) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+
+	want := []string{"deep.go", "file.go", "nested.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("AND pattern names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSeqMalformedPattern(t *testing.T) {
+	var gotErr error
+	for _, err := range FindSeq(context.Background(), ".", "a|") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error for malformed pattern")
+	}
+
+	if !errors.Is(gotErr, ErrMalformedPattern) {
+		t.Errorf("error = %v, want %v", gotErr, ErrMalformedPattern)
+	}
+}
+
+func TestFindSeqNonExistentDir(t *testing.T) {
+	var gotErr error
+	for _, err := range FindSeq(context.Background(), "/no/such/dir", "*.go") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected error for non-existent directory")
+	}
+}
+
+func TestFindSeqEarlyBreak(t *testing.T) {
+	root := testTree(t)
+
+	n := 0
+	for _, err := range FindSeq(context.Background(), root, "*.go", Recursive) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		n++
+		if n == 1 {
+			break
+		}
+	}
+
+	if n != 1 {
+		t.Errorf("early break: got %d iterations, want 1", n)
+	}
+}
+
+func TestFindSeqContextCancelled(t *testing.T) {
+	root := testTree(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	var gotErr error
+	for _, err := range FindSeq(ctx, root, "*.go") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if gotErr == nil {
+		t.Fatal("expected context cancelled error")
+	}
+}
+
+// --- Find tests ---
+
+func TestFind(t *testing.T) {
+	root := testTree(t)
+
+	got, err := Find(context.Background(), root, "*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"file.go", "file_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("Find(*.go) names = %v, want %v", g, want)
+	}
+}
+
+func TestFindRecursive(t *testing.T) {
+	root := testTree(t)
+
+	got, err := Find(context.Background(), root, "*.go", Recursive)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"deep.go", "file.go", "file_test.go", "nested.go", "nested_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("Find recursive names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSlicePattern(t *testing.T) {
+	root := testTree(t)
+
+	pattern := ParsePattern(false, "*.go", "*.md")
+	got, err := Find(context.Background(), root, pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"README.md", "file.go", "file_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("Find(ParsePattern) names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSlicePatternStrict(t *testing.T) {
+	root := testTree(t)
+
+	// Strict AND: must match *.go AND *file* — so file.go and file_test.go match.
+	pattern := ParsePattern(true, "*.go", "*file*")
+	got, err := Find(context.Background(), root, pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"file.go", "file_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("Find strict names = %v, want %v", g, want)
+	}
+}
+
+func TestFindSkipErrors(t *testing.T) {
+	// resolvePath pre-check bypasses SkipErrors for root-path errors.
+	_, err := Find(context.Background(), "/no/such/dir", "*.go", SkipErrors)
+	if err == nil {
+		t.Error("expected error for non-existent root, even with SkipErrors")
+	}
+}
+
+// --- FindWithIterator tests ---
+
+func TestFindWithIterator(t *testing.T) {
+	root := testTree(t)
+
+	outCh, errCh := FindWithIterator(context.Background(), root, "*.go")
+
+	var got []string
+	for p := range outCh {
+		got = append(got, p)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"file.go", "file_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("FindWithIterator names = %v, want %v", g, want)
+	}
+}
+
+func TestFindWithIteratorRecursive(t *testing.T) {
+	root := testTree(t)
+
+	outCh, errCh := FindWithIterator(context.Background(), root, "*.go", Recursive)
+
+	var got []string
+	for p := range outCh {
+		got = append(got, p)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"deep.go", "file.go", "file_test.go", "nested.go", "nested_test.go"}
+	if g := names(got); !slices.Equal(g, want) {
+		t.Errorf("FindWithIterator recursive names = %v, want %v", g, want)
+	}
+}
+
+// --- MatchAny / MatchAll tests ---
+
+func TestMatchAny(t *testing.T) {
+	ts := NewTemplates([]string{"*.go", "*.md"})
+
+	if !MatchAny(ts, "file.go") {
+		t.Error("MatchAny should match file.go")
+	}
+
+	if MatchAny(ts, "file.txt") {
+		t.Error("MatchAny should not match file.txt")
+	}
+}
+
+func TestMatchAll(t *testing.T) {
+	ts := NewTemplates([]string{"*file*", "*.go"})
+
+	if !MatchAll(ts, "file.go") {
+		t.Error("MatchAll should match file.go")
+	}
+
+	if MatchAll(ts, "README.md") {
+		t.Error("MatchAll should not match README.md")
+	}
+}
+
+// benchTree creates a temporary directory tree with the given breadth and
+// depth, placing one .go file and one .txt file in each directory.
+// Returns the root path and total number of .go files created.
+func benchTree(b *testing.B, breadth, depth int) (string, int) {
+	b.Helper()
+
+	root := b.TempDir()
+	goFiles := 0
+
+	var create func(dir string, level int)
+	create = func(dir string, level int) {
+		// Place files in every directory.
+		if err := os.WriteFile(filepath.Join(dir, "file.go"), nil, 0o644); err != nil {
+			b.Fatal(err)
+		}
+		goFiles++
+
+		if err := os.WriteFile(filepath.Join(dir, "file.txt"), nil, 0o644); err != nil {
+			b.Fatal(err)
 		}
 
-		if MatchAll(templates, el.Name()) {
-			// Do something here if match all of the templates...
+		if level >= depth {
+			return
 		}
+
+		for i := range breadth {
+			sub := filepath.Join(dir, "d"+string(rune('a'+i)))
+			if err := os.Mkdir(sub, 0o755); err != nil {
+				b.Fatal(err)
+			}
+
+			create(sub, level+1)
+		}
+	}
+
+	create(root, 0)
+
+	return root, goFiles
+}
+
+// --- Flat directory (no recursion) benchmarks ---
+
+func BenchmarkFind_Flat(b *testing.B) {
+	root := b.TempDir()
+	for i := range 50 {
+		name := "file" + string(rune('A'+i%26)) + string(rune('a'+i/26)) + ".go"
+		if err := os.WriteFile(filepath.Join(root, name), nil, 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := Find(ctx, root, "*.go")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindWithIterator_Flat(b *testing.B) {
+	root := b.TempDir()
+	for i := range 50 {
+		name := "file" + string(rune('A'+i%26)) + string(rune('a'+i/26)) + ".go"
+		if err := os.WriteFile(filepath.Join(root, name), nil, 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		outCh, errCh := FindWithIterator(ctx, root, "*.go")
+		for range outCh {
+		}
+
+		if err := <-errCh; err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindSeq_Flat(b *testing.B) {
+	root := b.TempDir()
+	for i := range 50 {
+		name := "file" + string(rune('A'+i%26)) + string(rune('a'+i/26)) + ".go"
+		if err := os.WriteFile(filepath.Join(root, name), nil, 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		for _, err := range FindSeq(ctx, root, "*.go") {
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// --- Recursive directory benchmarks ---
+
+func BenchmarkFind_Recursive(b *testing.B) {
+	root, _ := benchTree(b, 3, 3) // 3 subdirs x 3 levels = 40 directories
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := Find(ctx, root, "*.go", Recursive)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindWithIterator_Recursive(b *testing.B) {
+	root, _ := benchTree(b, 3, 3)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		outCh, errCh := FindWithIterator(ctx, root, "*.go", Recursive)
+		for range outCh {
+		}
+
+		if err := <-errCh; err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindSeq_Recursive(b *testing.B) {
+	root, _ := benchTree(b, 3, 3)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		for _, err := range FindSeq(ctx, root, "*.go", Recursive) {
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// --- Complex pattern benchmarks ---
+
+func BenchmarkFind_ComplexPattern(b *testing.B) {
+	root, _ := benchTree(b, 3, 3)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := Find(ctx, root, "*go*&!*test*", Recursive)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindWithIterator_ComplexPattern(b *testing.B) {
+	root, _ := benchTree(b, 3, 3)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		outCh, errCh := FindWithIterator(ctx, root, "*go*&!*test*", Recursive)
+		for range outCh {
+		}
+
+		if err := <-errCh; err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindSeq_ComplexPattern(b *testing.B) {
+	root, _ := benchTree(b, 3, 3)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		for _, err := range FindSeq(ctx, root, "*go*&!*test*", Recursive) {
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// --- Early termination benchmark (Max=1, large tree) ---
+
+func BenchmarkFind_EarlyTermination(b *testing.B) {
+	root, _ := benchTree(b, 3, 4)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		_, err := Find(ctx, root, "*.go", Recursive, Max(1))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindWithIterator_EarlyTermination(b *testing.B) {
+	root, _ := benchTree(b, 3, 4)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		outCh, errCh := FindWithIterator(ctx, root, "*.go", Recursive, Max(1))
+		for range outCh {
+		}
+
+		if err := <-errCh; err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFindSeq_EarlyTermination(b *testing.B) {
+	root, _ := benchTree(b, 3, 4)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for range b.N {
+		n := 0
+		for _, err := range FindSeq(ctx, root, "*.go", Recursive) {
+			if err != nil {
+				b.Fatal(err)
+			}
+			n++
+			if n == 1 {
+				break
+			}
+		}
+	}
+}
+
+// --- Template construction benchmarks ---
+
+func BenchmarkNewTemplate_Simple(b *testing.B) {
+	for range b.N {
+		NewTemplate("*.go")
+	}
+}
+
+func BenchmarkParseTemplate_Simple(b *testing.B) {
+	for range b.N {
+		_, err := ParseTemplate("*.go")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNewTemplate_Complex(b *testing.B) {
+	for range b.N {
+		NewTemplate("(*go*|*.md)&!*test*&!*vendor*")
+	}
+}
+
+func BenchmarkParseTemplate_Complex(b *testing.B) {
+	for range b.N {
+		_, err := ParseTemplate("(*go*|*.md)&!*test*&!*vendor*")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNewTemplate_Parens(b *testing.B) {
+	for range b.N {
+		NewTemplate("((*go*|*.md)&!*test*)|(*.txt&!*log*)")
+	}
+}
+
+func BenchmarkParseTemplate_Parens(b *testing.B) {
+	for range b.N {
+		_, err := ParseTemplate("((*go*|*.md)&!*test*)|(*.txt&!*log*)")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNewTemplates(b *testing.B) {
+	patterns := []string{"*.go", "*.md", "*test*", "!*vendor*"}
+
+	b.ResetTimer()
+	for range b.N {
+		NewTemplates(patterns)
+	}
+}
+
+func BenchmarkTemplateMatch(b *testing.B) {
+	tmpl, _ := ParseTemplate("*go*&!*test*")
+
+	b.ResetTimer()
+	for range b.N {
+		tmpl.Match("some/path/to/file.go")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/emar-kar/find
+module github.com/emar-kar/find/v2
 
-go 1.21
+go 1.23

--- a/options.go
+++ b/options.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strings"
 )
 
@@ -15,65 +14,46 @@ const (
 	Both
 )
 
-var sensitive = func(s string) string { return s }
-
 type (
-	optFunc   func(*options)
-	matchFunc func(Templates, string) bool
-	caseFunc  func(string) string
+	// Option configures [Find], [FindWithIterator], and [FindSeq] behaviour.
+	Option func(*options)
 
-	// Type to create custom slices of find options.
-	Options []optFunc
+	caseFunc func(string) string
 )
 
-// options allows to configure Find behavior.
+// options configures the behaviour of [Find], [FindWithIterator], and [FindSeq].
 type options struct {
-	matchFunc matchFunc
-	caseFunc  caseFunc
-	logger    io.Writer
-	output    io.Writer
-	orig      string
-	resOrig   string
-	max       int
-	maxIter   int
-	fType     uint8
-	iterCh    chan string
-	errCh     chan error
-	rec       bool
-	name      bool
-	relative  bool
-	full      bool
-	skip      bool
-	log       bool
-	iter      bool
-	out       bool
+	caseFunc caseFunc
+	tmpl     *Template
+	logger   io.Writer
+	output   io.Writer
+	orig     string
+	resOrig  string
+	max      int
+	maxIter  int
+	fType    uint8
+	rec      bool
+	name     bool
+	relative bool
+	full     bool
+	skip     bool
+	strict   bool
+	symlinks bool
 }
 
-// defaultOptions default [Find] options.
+// defaultOptions returns default options.
 func defaultOptions() *options {
 	return &options{
-		matchFunc: MatchAny,
-		caseFunc:  sensitive,
-		logger:    os.Stdout,
-		output:    os.Stdout,
-		maxIter:   100,
-		max:       -1,
-		fType:     Both,
+		// Sensetive case by default.
+		caseFunc: func(s string) string { return s },
+		maxIter:  100,
+		max:      -1,
+		fType:    Both,
 	}
-}
-
-func defaultOptionsWithCustom(opts ...optFunc) *options {
-	opt := defaultOptions()
-
-	for _, fn := range opts {
-		fn(opt)
-	}
-
-	return opt
 }
 
 func (o *options) logError(e error) error {
-	if o.log {
+	if o.logger != nil {
 		if _, err := fmt.Fprintf(o.logger, "error: %s\n", e); err != nil {
 			return fmt.Errorf("%w: %w", e, err)
 		}
@@ -87,7 +67,7 @@ func (o *options) logError(e error) error {
 }
 
 func (o *options) printOutput(str string) error {
-	if o.out {
+	if o.output != nil {
 		if _, err := fmt.Fprintln(o.output, str); err != nil {
 			return err
 		}
@@ -107,112 +87,151 @@ func (o *options) isSearchedType(isDir bool) bool {
 	}
 }
 
-func (o *options) match(ts Templates, fullPath string) bool {
-	if o.full {
-		return o.matchFunc(ts, o.caseFunc(fullPath))
+// match checks whether the entry at fullPath/name matches the template.
+// When [MatchFullPath] is set, the full path is matched; otherwise only the
+// entry name is used.
+func (o *options) match(fullPath, name string) bool {
+	if o.tmpl == nil {
+		return false
 	}
 
-	return o.matchFunc(ts, o.caseFunc(path.Base(fullPath)))
+	if o.full {
+		return o.tmpl.Match(o.caseFunc(fullPath))
+	}
+
+	return o.tmpl.Match(o.caseFunc(name))
 }
 
 // Deprecated: use [Only] instead.
-func SearchFor(t uint8) optFunc { return Only(t) }
+func SearchFor(t uint8) Option { return Only(t) }
 
 // Only defines if result should contains files, folders or both.
-func Only(t uint8) optFunc {
+func Only(t uint8) Option {
 	return func(o *options) {
 		o.fType = t
 	}
 }
 
-// Deprecated: use [Recursively] instead.
-func SearchRecursively(o *options) { Recursively(o) }
+// Deprecated: use [Recursive] instead.
+func Recursively(o *options) { Recursive(o) }
 
-// Recursively defines recursive search.
-func Recursively(o *options) { o.rec = true }
+// Recursive enables recursive directory search.
+func Recursive(o *options) { o.rec = true }
 
-// Deprecated: use [Name] instead.
-func SearchName(o *options) { Name(o) }
+// FollowSymlinks resolves symlinks during traversal.
+// When enabled, symlinks pointing to directories are recursed into
+// (requires [Recursive]) and reported as folders when [Only](Folder)
+// is set. Disabled by default to avoid unexpected behaviour with
+// circular symlinks.
+func FollowSymlinks(o *options) { o.symlinks = true }
 
-// Name defines if only names of files/folders should be
-// in the output.
-func Name(o *options) { o.name = true }
+// Deprecated: use [NamesOnly] instead.
+func Name(o *options) { NamesOnly(o) }
 
-// Deprecated: use [Strict] instead.
-func SearchStrict(o *options) { Strict(o) }
+// NamesOnly restricts the output to entry names only, omitting the path.
+func NamesOnly(o *options) { o.name = true }
 
-// Strict requires all templates to match searched path.
-func Strict(o *options) { o.matchFunc = MatchAll }
+// Strict changes the behaviour of [FindWithIterator] when a
+// []string pattern is given: instead of joining the patterns with OR
+// (any must match), they are joined with AND (all must match).
+// Has no effect on [Find] and [FindSeq], which accept a single string pattern.
+func Strict(o *options) { o.strict = true }
 
-// MatchFullPath matches full path not just the name.
+// MatchFullPath matches the full path instead of just the entry name.
 func MatchFullPath(o *options) { o.full = true }
 
 // RelativePaths does not resolve paths in the output.
 //
-// Note: does not work with [Name] option.
+// Note: does not work with [NamesOnly] option.
 func RelativePaths(o *options) { o.relative = true }
 
-// WithErrorsSkip skips errors during find execution.
+// Deprecated: use [SkipErrors] instead.
+func WithErrorsSkip(o *options) { SkipErrors(o) }
+
+// SkipErrors silently ignores non-critical errors during search.
+// Has no effect on [FindSeq], which always yields errors to the caller.
 //
-// Note: if the flag was set, [Find] will return nil error,
-// only if the base path was resolved.
-func WithErrorsSkip(o *options) { o.skip = true }
+// Note: if set, [Find] returns nil even when errors occur, as long
+// as the root path was resolved.
+func SkipErrors(o *options) { o.skip = true }
 
-// WithErrorsLog logs errors during find execution.
-// Defaults to [os.Stdout] and can be changed with [WithLogger].
-func WithErrorsLog(o *options) { o.log = true }
+// Deprecated: use [LogErrors] instead.
+func WithErrorsLog(o *options) { LogErrors(o) }
 
-// WithOutput prints results as soon as they match given [Templates].
-// Defaults to [os.Stdout] and can be changed with [WithWriter].
-func WithOutput(o *options) { o.out = true }
+// LogErrors logs errors to stderr (or the writer set by [WithLogger])
+// during search. Defaults to [os.Stderr].
+//
+// Deprecated: use [FindSeq] and handle errors directly in the iteration loop.
+func LogErrors(o *options) { o.logger = os.Stderr }
 
-// WithWriter allows to set custom [io.Writer] for [WithPrint].
-// Also sets [WithOutput] to true.
+// WithOutput prints results to [os.Stdout] as soon as they match.
+// Use [WithWriter] to set a custom writer.
+//
+// Deprecated: use [FindSeq] and write matches directly in the iteration loop.
+func WithOutput(o *options) { o.output = os.Stdout }
+
+// WithWriter sets a custom [io.Writer] for output. Also enables output.
+// Ignores nil writers.
 //
 // Note: write error counts as critical and will be returned
-// even if [WithErrorsSkip] was set.
-func WithWriter(out io.Writer) optFunc {
+// even if [SkipErrors] was set.
+//
+// Deprecated: use [FindSeq] and write matches directly in the iteration loop.
+func WithWriter(out io.Writer) Option {
 	return func(o *options) {
-		o.output = out
-		o.out = true
+		if out != nil {
+			o.output = out
+		}
 	}
 }
 
-// WithLogger allows to set custom logger for [WithErrorsLog].
-// Also sets [WithErrorsLog] to true.
+// WithLogger sets a custom [io.Writer] for error logging. Also enables
+// logging. Ignores nil writers.
 //
 // Note: write error counts as critical and will be returned
-// even if [WithErrorsSkip] was set.
-func WithLogger(l io.Writer) optFunc {
-	return func(o *options) {
-		o.logger = l
-		o.log = true
-	}
-}
-
-// WithMaxIterator allows to set custom output channel buffer.
+// even if [SkipErrors] was set.
 //
-// Note: can be used only with [FindWithIterator] or has no effect.
-func WithMaxIterator(max int) optFunc {
+// Deprecated: use [FindSeq] and handle errors directly in the iteration loop.
+func WithLogger(l io.Writer) Option {
 	return func(o *options) {
-		o.maxIter = max
+		if l != nil {
+			o.logger = l
+		}
 	}
 }
 
-// Max set maximum ammount of searched objects. [Find] will stop as
-// soon as reach the limit.
-func Max(i int) optFunc {
+// WithMaxIterator sets the buffer size of the output channel.
+// Values <= 0 are ignored; the default buffer size is 100.
+//
+// Deprecated: use [FindSeq] instead, which does not use channels.
+func WithMaxIterator(n int) Option {
 	return func(o *options) {
-		o.max = i
+		if n > 0 {
+			o.maxIter = n
+		}
 	}
 }
 
-// Insensitive sets case insensitive search.
-func Insensitive(o *options) {
+// Max sets the maximum number of results returned.
+// Traversal stops as soon as it reaches the limit.
+// Values <= 0 are ignored; the default behaviour is unlimited (-1).
+func Max(i int) Option {
+	return func(o *options) {
+		if i > 0 {
+			o.max = i
+		}
+	}
+}
+
+// Deprecated: use [CaseInsensitive] instead.
+func Insensitive(o *options) { CaseInsensitive(o) }
+
+// CaseInsensitive enables case-insensitive pattern matching.
+func CaseInsensitive(o *options) {
 	o.caseFunc = strings.ToLower
 }
 
-// MatchAny returns true if any of the given templates match the string.
+// MatchAny returns true if any of the given templates match str.
 func MatchAny(ts Templates, str string) bool {
 	for _, t := range ts {
 		if t.Match(str) {
@@ -223,7 +242,7 @@ func MatchAny(ts Templates, str string) bool {
 	return false
 }
 
-// MatchAll returns true if all of the given templates match the string.
+// MatchAll returns true if all of the given templates match str.
 func MatchAll(ts Templates, str string) bool {
 	for _, t := range ts {
 		if !t.Match(str) {

--- a/template.go
+++ b/template.go
@@ -8,160 +8,283 @@ import (
 )
 
 var (
-	ErrTemplateType = errors.New("cannot define type of the template")
-
-	// String representation of the current system path separator.
-	pathSeparator = string(os.PathSeparator)
+	ErrTemplateType     = errors.New("cannot define type of the template")
+	ErrMalformedPattern = errors.New("malformed pattern")
 )
 
-// Templater defines type constraint for generic Find function.
+// Templater defines the type constraint for [Find] and [FindWithIterator].
+// It will be deprecated in future versions; use [ParsePattern] to convert
+// a string or []string into a single pattern for [ParseTemplate].
 type Templater interface {
 	~string | ~[]string
 }
 
-// Template is a parsed version of each Find filter.
+// op identifies the kind of a Template node.
+type op int8
+
+const (
+	opLeaf op = iota // leaf: a base pattern with optional wildcards
+	opNot            // unary NOT: negates its left operand
+	opAnd            // binary AND: both left and right must match
+	opOr             // binary OR: either left or right must match
+)
+
+// Template is a parsed pattern tree used for matching paths.
 type Template struct {
-	and         *Template
-	or          *Template
+	op          op
+	left, right *Template
 	base        string
-	not         bool
 	strictLeft  bool
 	strictRight bool
 }
 
-// NewTemplate creates new Template from the given string.
+// NewTemplate creates a new [Template] from the given string without
+// validation. Malformed patterns (e.g. "a|", "|b") silently match nothing.
 //
-// String can contains:
-//
-//	*str*    - means that searched path should contain str
-//	str      - means that searched path should be str
-//	*str     - means that searched path should ends with str
-//	str*     - means that searched path should starts with str
-//	!*str*   - means that searched path should not contain str
-//	!str     - means that searched path should not be str
-//	!*str    - means that searched path should not end with str
-//	!str*    - means that searched path should not start with str
-//	str&str1 - means that searched path should be both str and str1
-//	str|str1 - means that searched path should be str or str1
-//
-// Option '&' defines nested paths e.g., '*str*&*str1*' - Find will search
-// for 'str' first and if it was found 'str1' inside it.
-//
-// Options '|' and '&' can contain as many elements as you need.
+// Deprecated: use [ParseTemplate] instead, which validates the pattern and
+// returns an error for malformed input.
 func NewTemplate(str string) *Template {
-	var t *Template
-
-	sep := strings.IndexFunc(str, func(r rune) bool {
-		if r == '&' || r == '|' {
-			return true
-		}
-
-		return false
-	})
-
-	if sep == -1 {
-		return parse(str)
-	}
-
-	switch str[sep] {
-	case '&':
-		t = parse(str[:sep])
-		t.and = NewTemplate(str[sep+1:])
-	case '|':
-		t = parse(str[:sep])
-		t.or = NewTemplate(str[sep+1:])
-	}
-
+	t, _ := buildTemplate(str)
 	return t
 }
 
-// parse parses string into the Template.
-func parse(str string) *Template {
-	t := new(Template)
+// findOuterSep returns the index of the first occurrence of sep at
+// parenthesis depth 0, or -1 if none is found.
+func findOuterSep(str string, sep byte) int {
+	depth := 0
 
-	t.not = strings.HasPrefix(str, "!")
-	str = strings.TrimPrefix(str, "!")
-
-	// If searched string is '*', then it will match
-	// any path it encounters. 'Not' will be ignored
-	// in this case.
-	if str == "*" {
-		t.strictLeft = false
-		t.strictRight = false
-		t.base = str
-
-		return t
+	for i := 0; i < len(str); i++ {
+		switch str[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case sep:
+			if depth == 0 {
+				return i
+			}
+		}
 	}
 
-	t.strictLeft = !strings.HasPrefix(str, "*")
-	str = strings.TrimPrefix(str, "*")
-	t.strictRight = !strings.HasSuffix(str, "*")
-	t.base = strings.TrimSuffix(str, "*")
+	return -1
+}
 
-	return t
+// isWrappedInParens reports whether str is entirely wrapped in a matching
+// pair of outer parentheses, e.g. "(a|b)" but not "(a)(b)".
+func isWrappedInParens(str string) bool {
+	if len(str) < 2 || str[0] != '(' || str[len(str)-1] != ')' {
+		return false
+	}
+
+	// Verify the opening '(' at position 0 is not closed before the last ')'.
+	depth := 0
+
+	for i := 0; i < len(str)-1; i++ {
+		switch str[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+
+		if depth == 0 {
+			return false // outer paren closed before end of string
+		}
+	}
+
+	return true
+}
+
+// buildTemplate parses str into a [Template], returning an error if any
+// segment is empty (malformed pattern). Splits on '|' first (lower
+// precedence), then delegates to [buildTemplateAnd] for '&'.
+func buildTemplate(str string) (*Template, error) {
+	if i := findOuterSep(str, '|'); i >= 0 {
+		left, err := buildTemplateAnd(str[:i])
+		if err != nil {
+			return left, err
+		}
+
+		right, err := buildTemplate(str[i+1:])
+		if err != nil {
+			return right, err
+		}
+
+		return &Template{op: opOr, left: left, right: right}, nil
+	}
+
+	return buildTemplateAnd(str)
+}
+
+// buildTemplateAnd handles '&' splitting (higher precedence than '|').
+func buildTemplateAnd(str string) (*Template, error) {
+	if i := findOuterSep(str, '&'); i >= 0 {
+		left, err := buildParse(str[:i])
+		if err != nil {
+			return left, err
+		}
+
+		right, err := buildTemplateAnd(str[i+1:])
+		if err != nil {
+			return right, err
+		}
+
+		return &Template{op: opAnd, left: left, right: right}, nil
+	}
+
+	return buildParse(str)
+}
+
+// buildParse handles a leading '!' and parenthesised groups before delegating
+// to [buildParseLiteral] for plain leaf patterns.
+func buildParse(str string) (*Template, error) {
+	not := false
+
+	if len(str) > 0 && str[0] == '!' {
+		not = true
+		str = str[1:]
+	}
+
+	if isWrappedInParens(str) {
+		inner, err := buildTemplate(str[1 : len(str)-1])
+		if err != nil {
+			return inner, err
+		}
+
+		if not {
+			return &Template{op: opNot, left: inner}, nil
+		}
+
+		return inner, nil
+	}
+
+	leaf, err := buildParseLiteral(str)
+	if err != nil {
+		return leaf, err
+	}
+
+	if not {
+		return &Template{op: opNot, left: leaf}, nil
+	}
+
+	return leaf, nil
+}
+
+// buildParseLiteral parses a single leaf pattern (wildcards and base string).
+// Returns [ErrMalformedPattern] if the resulting base is empty (empty segment).
+func buildParseLiteral(str string) (*Template, error) {
+	t := &Template{op: opLeaf}
+
+	// A lone '*' matches any path.
+	if str == "*" {
+		t.base = str
+		return t, nil
+	}
+
+	if len(str) > 0 && str[0] == '*' {
+		str = str[1:]
+	} else {
+		t.strictLeft = true
+	}
+
+	n := len(str)
+	if n > 0 && str[n-1] == '*' {
+		t.base = str[:n-1]
+	} else {
+		t.strictRight = true
+		t.base = str
+	}
+
+	// "**" (or similar) produces an empty base after stripping wildcards.
+	// Promote to the universal wildcard "*" so it matches everything.
+	if t.base == "" && (!t.strictLeft || !t.strictRight) {
+		t.base = "*"
+		t.strictLeft = false
+		t.strictRight = false
+	}
+
+	// Genuinely empty segment — e.g. from "a|" or "|b".
+	if t.base == "" {
+		return t, fmt.Errorf("%w: pattern contains an empty segment", ErrMalformedPattern)
+	}
+
+	return t, nil
 }
 
 // Match checks if given str matches the [Template].
 func (t *Template) Match(str string) bool {
-	var match bool
-
-	switch {
-	case t.base == "":
+	switch t.op {
+	case opLeaf:
+		return t.match(str)
+	case opNot:
+		return !t.left.Match(str)
+	case opAnd:
+		return t.left.Match(str) && t.right.Match(str)
+	case opOr:
+		return t.left.Match(str) || t.right.Match(str)
+	default:
 		return false
-	case t.base == "*":
-		match = true
-	case strings.Contains(str, t.base):
-		match = t.match(str)
-	case t.not:
-		match = true
 	}
-
-	if t.or != nil && !match {
-		match = t.or.Match(str)
-	}
-
-	if t.and != nil {
-		if !match {
-			return match
-		}
-
-		match = t.and.Match(str)
-	}
-
-	return match
 }
 
 func (t *Template) match(str string) bool {
-	match := true
-	sub := strings.Split(str, t.base)
-
-	left := len(sub) == 1 ||
-		sub[0] == "" ||
-		strings.HasSuffix(sub[0], pathSeparator)
-
-	right := len(sub) == 1 ||
-		sub[1] == "" ||
-		strings.HasPrefix(sub[1], pathSeparator)
-
-	switch {
-	case t.strictLeft && t.strictRight:
-		match = left && right
-	case t.strictLeft:
-		match = left
-	case t.strictRight:
-		match = right
+	switch t.base {
+	case "":
+		return false // genuinely empty segment — never matches
+	case "*":
+		return true // universal wildcard
 	}
 
-	if t.not {
-		match = !match
+	// Fast path: *base* pattern — any occurrence is valid, no boundary checks.
+	if !t.strictLeft && !t.strictRight {
+		return strings.Contains(str, t.base)
 	}
 
-	return match
+	// Strict path: loop until we find an occurrence that satisfies the
+	// required path-segment boundaries, or exhaust all occurrences.
+	baselen := len(t.base)
+	offset := 0
+	s := str
+
+	for {
+		idx := strings.Index(s, t.base)
+		if idx == -1 {
+			return false
+		}
+
+		realIdx := offset + idx
+		left := str[:realIdx]
+		right := str[realIdx+baselen:]
+
+		leftOK := left == "" || left[len(left)-1] == os.PathSeparator
+		rightOK := right == "" || right[0] == os.PathSeparator
+
+		var matchOK bool
+
+		switch {
+		case t.strictLeft && t.strictRight:
+			matchOK = leftOK && rightOK
+		case t.strictLeft:
+			matchOK = leftOK
+		default:
+			matchOK = rightOK
+		}
+
+		if matchOK {
+			return true
+		}
+
+		s = s[idx+baselen:]
+		offset += idx + baselen
+	}
 }
 
 type Templates []*Template
 
-// NewTemplates parses slice of strings into slice of Templates.
+// NewTemplates parses a slice of strings into a slice of [Template]s.
+//
+// Deprecated: use [ParseTemplate] instead, which validates each pattern and
+// returns an error for malformed input rather than silently matching nothing.
 func NewTemplates(t []string) Templates {
 	ts := make(Templates, 0, len(t))
 	for _, str := range t {
@@ -171,23 +294,101 @@ func NewTemplates(t []string) Templates {
 	return ts
 }
 
-func newTemplates[T Templater](t T, fn caseFunc) (Templates, error) {
-	var ts Templates
-
-	switch any(t).(type) {
-	case string:
-		ts = Templates{NewTemplate(fn(any(t).(string)))}
-	case []string:
-		sl := make([]string, 0, len(any(t).([]string)))
-
-		for _, str := range any(t).([]string) {
-			sl = append(sl, fn(str))
-		}
-
-		ts = NewTemplates(sl)
-	default:
-		return nil, fmt.Errorf("%w: %v", ErrTemplateType, t)
+// ParsePattern joins one or more pattern strings into a single combined
+// pattern suitable for [ParseTemplate].
+//
+//   - strict=false (default): patterns are OR-joined ("a|b|c"), so a path
+//     matching any of the given patterns is accepted.
+//   - strict=true: patterns are AND-joined ("(a)&(b)&(c)"), so a path must
+//     match every pattern. Each element is wrapped in parentheses to prevent
+//     precedence issues with patterns that already contain '|'.
+//
+// Returns "*" (match everything) if no templates are provided.
+func ParsePattern(strict bool, templates ...string) string {
+	if len(templates) == 0 {
+		return "*"
 	}
 
-	return ts, nil
+	builder := new(strings.Builder)
+	sep := '|'
+	if strict {
+		sep = '&'
+	}
+
+	for i, t := range templates {
+		if i > 0 {
+			builder.WriteRune(sep)
+		}
+
+		if strict {
+			builder.WriteByte('(')
+			builder.WriteString(t)
+			builder.WriteByte(')')
+		} else {
+			builder.WriteString(t)
+		}
+	}
+
+	return builder.String()
+}
+
+// checkBalancedParens returns [ErrMalformedPattern] if str contains
+// unbalanced or improperly nested parentheses.
+func checkBalancedParens(str string) error {
+	depth := 0
+
+	for i := 0; i < len(str); i++ {
+		switch str[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+
+			if depth < 0 {
+				return fmt.Errorf("%w: unmatched ')' in %q", ErrMalformedPattern, str)
+			}
+		}
+	}
+
+	if depth != 0 {
+		return fmt.Errorf("%w: unmatched '(' in %q", ErrMalformedPattern, str)
+	}
+
+	return nil
+}
+
+// ParseTemplate parses str into a [Template] and validates it.
+// Returns [ErrMalformedPattern] if the pattern contains an empty segment
+// (e.g. "a|", "|b", "a&" or an empty string) or unbalanced parentheses.
+//
+// Pattern syntax:
+//
+//	*str*    - path should contain str
+//	str      - path should equal str (at a path-segment boundary)
+//	*str     - path should end with str
+//	str*     - path should start with str
+//	!*str*   - path should not contain str
+//	!str     - path should not equal str
+//	!*str    - path should not end with str
+//	!str*    - path should not start with str
+//	str&str1 - both str and str1 must match (AND)
+//	str|str1 - either str or str1 must match (OR)
+//
+// '&' has higher precedence than '|', so *go*&!*test*|*mock* is parsed as
+// (*go* AND !*test*) OR *mock*, not *go* AND (!*test* OR *mock*).
+// Both operators can be chained with as many elements as needed.
+//
+// Parentheses can be used to override the default '&' > '|' precedence:
+//
+//	(str|str1)&str2 - (str OR str1) AND str2
+//	!(str&str1)     - NOT (str AND str1)
+//
+// The only all-wildcard pattern that matches everything is "*" (or "**",
+// which is normalised to "*").
+func ParseTemplate(str string) (*Template, error) {
+	if err := checkBalancedParens(str); err != nil {
+		return nil, err
+	}
+
+	return buildTemplate(str)
 }


### PR DESCRIPTION
# Iterator-first API, template tree refactor, and comprehensive tests

## Summary

This PR introduces `FindSeq` — an iterator-based search function built on Go 1.23+ `iter.Seq2` — as the primary API for the `find` package. The template matching engine is refactored from a flat linked-list to a binary-operator tree with support for parenthesised grouping. All public APIs receive updated documentation, deprecated functions are clearly marked, and the package gets comprehensive test and benchmark coverage for the first time.

## Highlights

### New: `FindSeq` (iterator-based search)

```go
for path, err := range find.FindSeq(ctx, "/src", "*.go", find.Recursive) {
    if err != nil { log.Println(err); continue }
    fmt.Println(path)
}
```

- Returns `iter.Seq2[string, error]` — use with `for range`, `break` to stop early
- Setup errors (bad path, malformed pattern) yielded on first iteration
- Mid-walk errors yielded inline; traversal continues
- No goroutines, no channels, no buffering

### New: `Find` simplified

`Find` is no longer generic — it takes a `string` pattern directly and wraps `FindSeq`, collecting results into a slice. For multi-pattern use cases, combine patterns with the new `ParsePattern`.

### New: `ParsePattern`

```go
pattern := find.ParsePattern(false, "*.go", "*.md")       // OR-joined
pattern := find.ParsePattern(true, "*.go", "*file*")       // AND-joined
```

Replaces the old generic `Templater`-based pattern resolution with a simple variadic function. `Templater` is marked for future deprecation.

### Template engine: binary-operator tree with parentheses

The `Template` struct is refactored from `and`/`or`/`not` pointer chains to a proper binary tree with `op` discriminator (`opLeaf`, `opNot`, `opAnd`, `opOr`). This enables:

- **Parenthesised grouping**: `(*.go|*.md)&!*test*`, `!(a&b)`
- **Correct precedence**: `&` binds tighter than `|`
- **Inline validation**: `buildTemplate` validates during construction (no separate tree walk), making `ParseTemplate` ~10% faster

### New: `ParseTemplate` with validation

```go
tmpl, err := find.ParseTemplate("*go*&!*test*")
```

Returns `ErrMalformedPattern` for empty segments (`"a|"`, `"|b"`) and unbalanced parentheses. `NewTemplate` is deprecated but retained, silently ignoring errors.

### Comprehensive tests and benchmarks

- **25 functional tests** covering `ParseTemplate`, `FindSeq`, `Find`, `FindWithIterator`, `MatchAny`, `MatchAll`
- **Benchmarks** comparing `Find` vs `FindWithIterator` vs `FindSeq` across flat, recursive, complex-pattern, and early-termination scenarios
- **Template benchmarks** comparing `NewTemplate` vs `ParseTemplate` for simple, complex, and parenthesised patterns

## Breaking changes

| Change | Migration |
|--------|-----------|
| `Find` no longer generic — takes `string` | Use `ParsePattern(strict, patterns...)` to combine `[]string` into a single pattern |
| `optFunc` renamed to `Option` (exported) | Update type references; function signatures unchanged |
| `Options` type alias removed | Use `[]Option` directly |
| `defaultOptionsWithCustom` removed | Options now applied inline in each function |
| Go minimum version: **1.23** | Required for `iter` package |

## Deprecated (kept for backward compatibility)

| Symbol | Replacement |
|--------|-------------|
| `FindWithIterator` | `FindSeq` |
| `NewTemplate` / `NewTemplates` | `ParseTemplate` |
| `Templater` | `ParsePattern` |
| `LogErrors` | Handle errors in `FindSeq` loop |
| `WithOutput` / `WithWriter` | Write matches in `FindSeq` loop |
| `WithLogger` | Log errors in `FindSeq` loop |
| `WithMaxIterator` | Not needed — `FindSeq` has no channel |
| `SearchFor` | `Only` |
| `Recursively` | `Recursive` |
| `Name` | `NamesOnly` |
| `Insensitive` | `CaseInsensitive` |
| `WithErrorsSkip` | `SkipErrors` |
| `WithErrorsLog` | `LogErrors` |

## Options

| Option | Description |
|--------|-------------|
| `Recursive` | Search subdirectories recursively |
| `Only(t)` | Filter by type: `File`, `Folder`, or `Both` |
| `NamesOnly` | Return entry names only |
| `RelativePaths` | Keep paths relative to *where* |
| `MatchFullPath` | Match against the full path |
| `CaseInsensitive` | Case-insensitive matching |
| `FollowSymlinks` | Resolve and follow symlinks |
| `Max(n)` | Limit number of results |
| `Strict` | AND-join `[]string` patterns (for `FindWithIterator`) |
| `SkipErrors` | Silently ignore non-critical errors |
