### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,12 @@ iteration. Use `break` to stop early.
 ### Find
 
 ```go
-func Find[T Templater](ctx context.Context, where string, t T, opts ...Option) ([]string, error)
+func Find(ctx context.Context, where string, pattern string, opts ...Option) ([]string, error)
 ```
 
-Collects all matches into a slice and returns them. Kept for backward
+Finds all matches into a slice and returns them. Kept for backward
 compatibility — prefer `FindSeq` for streaming results without allocating a
 result slice. Accepts `string` or `[]string` patterns.
-
-### FindWithIterator *(deprecated)*
-
-```go
-func FindWithIterator[T Templater](ctx context.Context, where string, t T, opts ...Option) (chan string, chan error)
-```
-
-Channel-based iteration. **Deprecated** — use `FindSeq` instead.
 
 ### ParseTemplate
 
@@ -104,29 +96,15 @@ option slices with `[]find.Option{...}`.
 
 | Option            | Description                                            |
 |-------------------|--------------------------------------------------------|
-| `Recursive`       | Search subdirectories recursively.                     |
 | `Only(t)`         | Filter by type: `File`, `Folder`, or `Both` (default). |
-| `NamesOnly`       | Return entry names only, not full paths.               |
-| `RelativePaths`   | Keep paths relative to *where*.                        |
-| `MatchFullPath`   | Match against the full path, not just the entry name.  |
-| `CaseInsensitive` | Case-insensitive pattern matching.                     |
+| `Recursive`       | Search subdirectories recursively.                     |
 | `FollowSymlinks`  | Resolve and follow symlinks during traversal.          |
-| `Max(n)`          | Limit the number of results.                           |
-| `Strict`          | AND-join `[]string` patterns instead of OR-join.       |
+| `NamesOnly`       | Return entry names only, not full paths.               |
+| `MatchFullPath`   | Match against the full path, not just the entry name.  |
+| `RelativePaths`   | Keep paths relative to *where*.                        |
 | `SkipErrors`      | Silently ignore non-critical errors (`Find` only).     |
-
-### Deprecated options
-
-These remain for `Find`/`FindWithIterator` compatibility. With `FindSeq`,
-handle output and errors directly in the loop.
-
-| Option             | Replacement                              |
-|--------------------|------------------------------------------|
-| `LogErrors`        | Handle errors in the `FindSeq` loop.     |
-| `WithOutput`       | Print matches in the `FindSeq` loop.     |
-| `WithWriter(w)`    | Write matches in the `FindSeq` loop.     |
-| `WithLogger(w)`    | Log errors in the `FindSeq` loop.        |
-| `WithMaxIterator(n)` | Not needed — `FindSeq` has no channel. |
+| `Max(n)`          | Limit the number of results.                           |
+| `CaseInsensitive` | Case-insensitive pattern matching.                     |
 
 ## Usage examples
 

--- a/find.go
+++ b/find.go
@@ -3,7 +3,6 @@ package find
 
 import (
 	"context"
-	"fmt"
 	"iter"
 	"os"
 	"path/filepath"
@@ -46,8 +45,8 @@ func FindSeq(
 }
 
 // findSeqWithOpts is the internal implementation of [FindSeq] that accepts
-// a pre-built *options, allowing [Find] and [FindWithIterator] to share
-// the same options struct without double-instantiation.
+// a pre-built *options, allowing [Find] to share the same options struct
+// without double-instantiation.
 func findSeqWithOpts(
 	ctx context.Context, where, pattern string, opt *options,
 ) iter.Seq2[string, error] {
@@ -151,10 +150,6 @@ func processEntrySeq(
 	if opt.isSearchedType(isDir) && opt.match(p, f.Name()) {
 		found := formatFound(f, p, opt)
 
-		if err := opt.printOutput(found); err != nil {
-			return yield("", err)
-		}
-
 		if !yield(found, nil) {
 			return false
 		}
@@ -196,84 +191,7 @@ func formatFound(f os.DirEntry, p string, opt *options) string {
 	}
 }
 
-// FindWithIterator returns channel-based iteration over matches.
-// String channel yields every match. Error channel carries the first
-// occurred error or, if [SkipErrors] was set, the first critical error.
-// Both channels are closed once the search completes or is interrupted.
-//
-//	outCh, errCh := FindWithIterator(ctx, where, ts, opts...)
-//	for f := range outCh {
-//		// do something here...
-//	}
-//	if err := <-errCh {
-//		// process error...
-//	}
-//
-// NOTE: output channel must be consumed by the caller to avoid a deadlock.
-//
-// Deprecated: use [FindSeq] instead for pull-based iteration without
-// goroutines or channels.
-func FindWithIterator[T Templater](
-	ctx context.Context,
-	where string,
-	t T,
-	opts ...Option,
-) (chan string, chan error) {
-	opt := defaultOptions()
-
-	for _, fn := range opts {
-		fn(opt)
-	}
-
-	iterCh := make(chan string, opt.maxIter)
-	errCh := make(chan error, 1)
-
-	go func() {
-		defer func() {
-			close(iterCh)
-			close(errCh)
-		}()
-
-		resPath, err := resolvePath(where)
-		if err != nil {
-			errCh <- err
-			return
-		}
-
-		opt.orig = where
-		opt.resOrig = resPath
-
-		var pattern string
-		switch v := any(t).(type) {
-		case string:
-			pattern = v
-		case []string:
-			pattern = ParsePattern(opt.strict, v...)
-		default:
-			errCh <- fmt.Errorf("%w: %v", ErrTemplateType, t)
-			return
-		}
-
-		tmpl, err := ParseTemplate(opt.caseFunc(pattern))
-		if err != nil {
-			errCh <- err
-			return
-		}
-
-		opt.tmpl = tmpl
-
-		if err := findOld(ctx, resPath, opt, iterCh, nil); err != nil {
-			errCh <- err
-		}
-	}()
-
-	return iterCh, errCh
-}
-
-// Find searches for matches with the given templates in where and returns
-// all results as a slice. Accepts a string or []string pattern (see
-// [Templater]). Use Find when you need the complete result set before
-// processing; use [FindSeq] when streaming or early termination is preferred.
+// Find collects matches into a slice before return.
 func Find(
 	ctx context.Context, where, pattern string, opts ...Option,
 ) ([]string, error) {
@@ -288,68 +206,4 @@ func Find(
 	}
 
 	return result, nil
-}
-
-// findOld is the original recursive traversal used by [Find] and
-// [FindWithIterator]. When iterCh is non-nil, matches are sent to the
-// channel; otherwise they are appended to result.
-func findOld(
-	ctx context.Context,
-	where string,
-	opt *options,
-	iterCh chan<- string,
-	result *[]string,
-) error {
-	entries, err := os.ReadDir(where)
-	if err != nil {
-		return opt.logError(err)
-	}
-
-	for _, f := range entries {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			if opt.max == 0 {
-				return nil
-			}
-
-			p := filepath.Join(where, f.Name())
-
-			if opt.isSearchedType(f.IsDir()) && opt.match(p, f.Name()) {
-				var found string
-
-				switch {
-				case opt.name:
-					found = f.Name()
-				case opt.relative:
-					found = strings.Replace(p, opt.resOrig, opt.orig, 1)
-				default:
-					found = p
-				}
-
-				if err := opt.printOutput(found); err != nil {
-					return opt.logError(err)
-				}
-
-				if iterCh != nil {
-					iterCh <- found
-				} else {
-					*result = append(*result, found)
-				}
-
-				if opt.max != -1 {
-					opt.max--
-				}
-			}
-
-			if opt.rec && f.IsDir() {
-				if err := findOld(ctx, p, opt, iterCh, result); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
 }

--- a/find_test.go
+++ b/find_test.go
@@ -475,74 +475,6 @@ func TestFindSkipErrors(t *testing.T) {
 	}
 }
 
-// --- FindWithIterator tests ---
-
-func TestFindWithIterator(t *testing.T) {
-	root := testTree(t)
-
-	outCh, errCh := FindWithIterator(context.Background(), root, "*.go")
-
-	var got []string
-	for p := range outCh {
-		got = append(got, p)
-	}
-
-	if err := <-errCh; err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{"file.go", "file_test.go"}
-	if g := names(got); !slices.Equal(g, want) {
-		t.Errorf("FindWithIterator names = %v, want %v", g, want)
-	}
-}
-
-func TestFindWithIteratorRecursive(t *testing.T) {
-	root := testTree(t)
-
-	outCh, errCh := FindWithIterator(context.Background(), root, "*.go", Recursive)
-
-	var got []string
-	for p := range outCh {
-		got = append(got, p)
-	}
-
-	if err := <-errCh; err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{"deep.go", "file.go", "file_test.go", "nested.go", "nested_test.go"}
-	if g := names(got); !slices.Equal(g, want) {
-		t.Errorf("FindWithIterator recursive names = %v, want %v", g, want)
-	}
-}
-
-// --- MatchAny / MatchAll tests ---
-
-func TestMatchAny(t *testing.T) {
-	ts := NewTemplates([]string{"*.go", "*.md"})
-
-	if !MatchAny(ts, "file.go") {
-		t.Error("MatchAny should match file.go")
-	}
-
-	if MatchAny(ts, "file.txt") {
-		t.Error("MatchAny should not match file.txt")
-	}
-}
-
-func TestMatchAll(t *testing.T) {
-	ts := NewTemplates([]string{"*file*", "*.go"})
-
-	if !MatchAll(ts, "file.go") {
-		t.Error("MatchAll should match file.go")
-	}
-
-	if MatchAll(ts, "README.md") {
-		t.Error("MatchAll should not match README.md")
-	}
-}
-
 // benchTree creates a temporary directory tree with the given breadth and
 // depth, placing one .go file and one .txt file in each directory.
 // Returns the root path and total number of .go files created.
@@ -605,29 +537,6 @@ func BenchmarkFind_Flat(b *testing.B) {
 	}
 }
 
-func BenchmarkFindWithIterator_Flat(b *testing.B) {
-	root := b.TempDir()
-	for i := range 50 {
-		name := "file" + string(rune('A'+i%26)) + string(rune('a'+i/26)) + ".go"
-		if err := os.WriteFile(filepath.Join(root, name), nil, 0o644); err != nil {
-			b.Fatal(err)
-		}
-	}
-
-	ctx := context.Background()
-
-	b.ResetTimer()
-	for range b.N {
-		outCh, errCh := FindWithIterator(ctx, root, "*.go")
-		for range outCh {
-		}
-
-		if err := <-errCh; err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func BenchmarkFindSeq_Flat(b *testing.B) {
 	root := b.TempDir()
 	for i := range 50 {
@@ -664,22 +573,6 @@ func BenchmarkFind_Recursive(b *testing.B) {
 	}
 }
 
-func BenchmarkFindWithIterator_Recursive(b *testing.B) {
-	root, _ := benchTree(b, 3, 3)
-	ctx := context.Background()
-
-	b.ResetTimer()
-	for range b.N {
-		outCh, errCh := FindWithIterator(ctx, root, "*.go", Recursive)
-		for range outCh {
-		}
-
-		if err := <-errCh; err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func BenchmarkFindSeq_Recursive(b *testing.B) {
 	root, _ := benchTree(b, 3, 3)
 	ctx := context.Background()
@@ -704,22 +597,6 @@ func BenchmarkFind_ComplexPattern(b *testing.B) {
 	for range b.N {
 		_, err := Find(ctx, root, "*go*&!*test*", Recursive)
 		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkFindWithIterator_ComplexPattern(b *testing.B) {
-	root, _ := benchTree(b, 3, 3)
-	ctx := context.Background()
-
-	b.ResetTimer()
-	for range b.N {
-		outCh, errCh := FindWithIterator(ctx, root, "*go*&!*test*", Recursive)
-		for range outCh {
-		}
-
-		if err := <-errCh; err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -754,22 +631,6 @@ func BenchmarkFind_EarlyTermination(b *testing.B) {
 	}
 }
 
-func BenchmarkFindWithIterator_EarlyTermination(b *testing.B) {
-	root, _ := benchTree(b, 3, 4)
-	ctx := context.Background()
-
-	b.ResetTimer()
-	for range b.N {
-		outCh, errCh := FindWithIterator(ctx, root, "*.go", Recursive, Max(1))
-		for range outCh {
-		}
-
-		if err := <-errCh; err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func BenchmarkFindSeq_EarlyTermination(b *testing.B) {
 	root, _ := benchTree(b, 3, 4)
 	ctx := context.Background()
@@ -791,24 +652,12 @@ func BenchmarkFindSeq_EarlyTermination(b *testing.B) {
 
 // --- Template construction benchmarks ---
 
-func BenchmarkNewTemplate_Simple(b *testing.B) {
-	for range b.N {
-		NewTemplate("*.go")
-	}
-}
-
 func BenchmarkParseTemplate_Simple(b *testing.B) {
 	for range b.N {
 		_, err := ParseTemplate("*.go")
 		if err != nil {
 			b.Fatal(err)
 		}
-	}
-}
-
-func BenchmarkNewTemplate_Complex(b *testing.B) {
-	for range b.N {
-		NewTemplate("(*go*|*.md)&!*test*&!*vendor*")
 	}
 }
 
@@ -821,27 +670,12 @@ func BenchmarkParseTemplate_Complex(b *testing.B) {
 	}
 }
 
-func BenchmarkNewTemplate_Parens(b *testing.B) {
-	for range b.N {
-		NewTemplate("((*go*|*.md)&!*test*)|(*.txt&!*log*)")
-	}
-}
-
 func BenchmarkParseTemplate_Parens(b *testing.B) {
 	for range b.N {
 		_, err := ParseTemplate("((*go*|*.md)&!*test*)|(*.txt&!*log*)")
 		if err != nil {
 			b.Fatal(err)
 		}
-	}
-}
-
-func BenchmarkNewTemplates(b *testing.B) {
-	patterns := []string{"*.go", "*.md", "*test*", "!*vendor*"}
-
-	b.ResetTimer()
-	for range b.N {
-		NewTemplates(patterns)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -1,11 +1,6 @@
 package find
 
-import (
-	"fmt"
-	"io"
-	"os"
-	"strings"
-)
+import "strings"
 
 // Type of the searched object.
 const (
@@ -15,29 +10,25 @@ const (
 )
 
 type (
-	// Option configures [Find], [FindWithIterator], and [FindSeq] behaviour.
+	// Option configures [Find] and [FindSeq] Behavior.
 	Option func(*options)
 
 	caseFunc func(string) string
 )
 
-// options configures the behaviour of [Find], [FindWithIterator], and [FindSeq].
+// options configures the Behavior of [Find] and [FindSeq].
 type options struct {
 	caseFunc caseFunc
 	tmpl     *Template
-	logger   io.Writer
-	output   io.Writer
 	orig     string
 	resOrig  string
 	max      int
-	maxIter  int
 	fType    uint8
 	rec      bool
 	name     bool
 	relative bool
 	full     bool
 	skip     bool
-	strict   bool
 	symlinks bool
 }
 
@@ -46,34 +37,9 @@ func defaultOptions() *options {
 	return &options{
 		// Sensetive case by default.
 		caseFunc: func(s string) string { return s },
-		maxIter:  100,
 		max:      -1,
 		fType:    Both,
 	}
-}
-
-func (o *options) logError(e error) error {
-	if o.logger != nil {
-		if _, err := fmt.Fprintf(o.logger, "error: %s\n", e); err != nil {
-			return fmt.Errorf("%w: %w", e, err)
-		}
-	}
-
-	if o.skip {
-		return nil
-	}
-
-	return e
-}
-
-func (o *options) printOutput(str string) error {
-	if o.output != nil {
-		if _, err := fmt.Fprintln(o.output, str); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (o *options) isSearchedType(isDir bool) bool {
@@ -102,9 +68,6 @@ func (o *options) match(fullPath, name string) bool {
 	return o.tmpl.Match(o.caseFunc(name))
 }
 
-// Deprecated: use [Only] instead.
-func SearchFor(t uint8) Option { return Only(t) }
-
 // Only defines if result should contains files, folders or both.
 func Only(t uint8) Option {
 	return func(o *options) {
@@ -112,30 +75,18 @@ func Only(t uint8) Option {
 	}
 }
 
-// Deprecated: use [Recursive] instead.
-func Recursively(o *options) { Recursive(o) }
-
 // Recursive enables recursive directory search.
 func Recursive(o *options) { o.rec = true }
 
 // FollowSymlinks resolves symlinks during traversal.
 // When enabled, symlinks pointing to directories are recursed into
 // (requires [Recursive]) and reported as folders when [Only](Folder)
-// is set. Disabled by default to avoid unexpected behaviour with
+// is set. Disabled by default to avoid unexpected Behavior with
 // circular symlinks.
 func FollowSymlinks(o *options) { o.symlinks = true }
 
-// Deprecated: use [NamesOnly] instead.
-func Name(o *options) { NamesOnly(o) }
-
 // NamesOnly restricts the output to entry names only, omitting the path.
 func NamesOnly(o *options) { o.name = true }
-
-// Strict changes the behaviour of [FindWithIterator] when a
-// []string pattern is given: instead of joining the patterns with OR
-// (any must match), they are joined with AND (all must match).
-// Has no effect on [Find] and [FindSeq], which accept a single string pattern.
-func Strict(o *options) { o.strict = true }
 
 // MatchFullPath matches the full path instead of just the entry name.
 func MatchFullPath(o *options) { o.full = true }
@@ -145,9 +96,6 @@ func MatchFullPath(o *options) { o.full = true }
 // Note: does not work with [NamesOnly] option.
 func RelativePaths(o *options) { o.relative = true }
 
-// Deprecated: use [SkipErrors] instead.
-func WithErrorsSkip(o *options) { SkipErrors(o) }
-
 // SkipErrors silently ignores non-critical errors during search.
 // Has no effect on [FindSeq], which always yields errors to the caller.
 //
@@ -155,66 +103,9 @@ func WithErrorsSkip(o *options) { SkipErrors(o) }
 // as the root path was resolved.
 func SkipErrors(o *options) { o.skip = true }
 
-// Deprecated: use [LogErrors] instead.
-func WithErrorsLog(o *options) { LogErrors(o) }
-
-// LogErrors logs errors to stderr (or the writer set by [WithLogger])
-// during search. Defaults to [os.Stderr].
-//
-// Deprecated: use [FindSeq] and handle errors directly in the iteration loop.
-func LogErrors(o *options) { o.logger = os.Stderr }
-
-// WithOutput prints results to [os.Stdout] as soon as they match.
-// Use [WithWriter] to set a custom writer.
-//
-// Deprecated: use [FindSeq] and write matches directly in the iteration loop.
-func WithOutput(o *options) { o.output = os.Stdout }
-
-// WithWriter sets a custom [io.Writer] for output. Also enables output.
-// Ignores nil writers.
-//
-// Note: write error counts as critical and will be returned
-// even if [SkipErrors] was set.
-//
-// Deprecated: use [FindSeq] and write matches directly in the iteration loop.
-func WithWriter(out io.Writer) Option {
-	return func(o *options) {
-		if out != nil {
-			o.output = out
-		}
-	}
-}
-
-// WithLogger sets a custom [io.Writer] for error logging. Also enables
-// logging. Ignores nil writers.
-//
-// Note: write error counts as critical and will be returned
-// even if [SkipErrors] was set.
-//
-// Deprecated: use [FindSeq] and handle errors directly in the iteration loop.
-func WithLogger(l io.Writer) Option {
-	return func(o *options) {
-		if l != nil {
-			o.logger = l
-		}
-	}
-}
-
-// WithMaxIterator sets the buffer size of the output channel.
-// Values <= 0 are ignored; the default buffer size is 100.
-//
-// Deprecated: use [FindSeq] instead, which does not use channels.
-func WithMaxIterator(n int) Option {
-	return func(o *options) {
-		if n > 0 {
-			o.maxIter = n
-		}
-	}
-}
-
 // Max sets the maximum number of results returned.
 // Traversal stops as soon as it reaches the limit.
-// Values <= 0 are ignored; the default behaviour is unlimited (-1).
+// Values <= 0 are ignored; the default Behavior is unlimited (-1).
 func Max(i int) Option {
 	return func(o *options) {
 		if i > 0 {
@@ -223,32 +114,7 @@ func Max(i int) Option {
 	}
 }
 
-// Deprecated: use [CaseInsensitive] instead.
-func Insensitive(o *options) { CaseInsensitive(o) }
-
 // CaseInsensitive enables case-insensitive pattern matching.
 func CaseInsensitive(o *options) {
 	o.caseFunc = strings.ToLower
-}
-
-// MatchAny returns true if any of the given templates match str.
-func MatchAny(ts Templates, str string) bool {
-	for _, t := range ts {
-		if t.Match(str) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// MatchAll returns true if all of the given templates match str.
-func MatchAll(ts Templates, str string) bool {
-	for _, t := range ts {
-		if !t.Match(str) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/template.go
+++ b/template.go
@@ -12,21 +12,18 @@ var (
 	ErrMalformedPattern = errors.New("malformed pattern")
 )
 
-// Templater defines the type constraint for [Find] and [FindWithIterator].
-// It will be deprecated in future versions; use [ParsePattern] to convert
-// a string or []string into a single pattern for [ParseTemplate].
-type Templater interface {
-	~string | ~[]string
-}
-
 // op identifies the kind of a Template node.
 type op int8
 
 const (
-	opLeaf op = iota // leaf: a base pattern with optional wildcards
-	opNot            // unary NOT: negates its left operand
-	opAnd            // binary AND: both left and right must match
-	opOr             // binary OR: either left or right must match
+	// A base pattern with optional wildcards.
+	opLeaf op = iota
+	// NOT: negates its left operand.
+	opNot
+	// AND: both left and right must match.
+	opAnd
+	// OR: either left or right must match.
+	opOr
 )
 
 // Template is a parsed pattern tree used for matching paths.
@@ -36,16 +33,6 @@ type Template struct {
 	base        string
 	strictLeft  bool
 	strictRight bool
-}
-
-// NewTemplate creates a new [Template] from the given string without
-// validation. Malformed patterns (e.g. "a|", "|b") silently match nothing.
-//
-// Deprecated: use [ParseTemplate] instead, which validates the pattern and
-// returns an error for malformed input.
-func NewTemplate(str string) *Template {
-	t, _ := buildTemplate(str)
-	return t
 }
 
 // findOuterSep returns the index of the first occurrence of sep at
@@ -88,7 +75,7 @@ func isWrappedInParens(str string) bool {
 		}
 
 		if depth == 0 {
-			return false // outer paren closed before end of string
+			return false // Outer paren closed before end of string.
 		}
 	}
 
@@ -230,9 +217,9 @@ func (t *Template) Match(str string) bool {
 func (t *Template) match(str string) bool {
 	switch t.base {
 	case "":
-		return false // genuinely empty segment — never matches
+		return false // Empty segment — never matches.
 	case "*":
-		return true // universal wildcard
+		return true // Universal wildcard - always matches.
 	}
 
 	// Fast path: *base* pattern — any occurrence is valid, no boundary checks.
@@ -281,17 +268,34 @@ func (t *Template) match(str string) bool {
 
 type Templates []*Template
 
-// NewTemplates parses a slice of strings into a slice of [Template]s.
+// MatchAny returns true if any of the given templates match str.
 //
-// Deprecated: use [ParseTemplate] instead, which validates each pattern and
-// returns an error for malformed input rather than silently matching nothing.
-func NewTemplates(t []string) Templates {
-	ts := make(Templates, 0, len(t))
-	for _, str := range t {
-		ts = append(ts, NewTemplate(str))
+// Deprecated: usage of this functions is discouraged in favor of
+// constructing one [Template] from string or []string and use Match
+// on it.
+func MatchAny(ts Templates, str string) bool {
+	for _, t := range ts {
+		if t.Match(str) {
+			return true
+		}
 	}
 
-	return ts
+	return false
+}
+
+// MatchAll returns true if all of the given templates match str.
+//
+// Deprecated: usage of this functions is discouraged in favor of
+// constructing one [Template] from string or []string and use Match
+// on it.
+func MatchAll(ts Templates, str string) bool {
+	for _, t := range ts {
+		if !t.Match(str) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // ParsePattern joins one or more pattern strings into a single combined
@@ -333,6 +337,15 @@ func ParsePattern(strict bool, templates ...string) string {
 	}
 
 	return builder.String()
+}
+
+// CreateTemplate combines parsing pattern and creating [Template].
+// Since pattern parsing is a save operation, which guarantees correct
+// output string, it must not return any error from template creation
+// and thus can be safe to call as is.
+func CreateTemplate(strict bool, sl ...string) *Template {
+	t, _ := ParseTemplate(ParsePattern(strict, sl...))
+	return t
 }
 
 // removeEmpty removes empty strings from sl.


### PR DESCRIPTION
* Add safe CreateTemplate to construct Template from patterns parsed

Deprecated:

* MatchAny
* MatchAll

Removed:

* Templater interface
* FindWithIterator function
* SearchFor option
* Recursively option
* Name option
* Strict option
* WithErrorsSkip option
* WithErrorsLog option
* LogErrors option
* WithOutput option
* WithWriter option
* WithLogger option
* WithMaxIterator option
* Insensitive option